### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP server that leverages multiple Claude instances to provide enhanced responses. It sends the same prompt to two separate instances of Claude and uses a third instance to combine or select the best elements from both responses.
 
+<a href="https://glama.ai/mcp/servers/@LazerThings/twosplit">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@LazerThings/twosplit/badge" alt="Twosplit Server MCP server" />
+</a>
+
 ## Features
 
 - Supports multiple Claude models:
@@ -80,3 +84,4 @@ To inspect the server's capabilities:
 
 ```bash
 npm run inspector
+```


### PR DESCRIPTION
This PR adds a badge for the [Twosplit MCP Server](https://glama.ai/mcp/servers/@LazerThings/twosplit) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@LazerThings/twosplit">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@LazerThings/twosplit/badge" alt="Twosplit Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.